### PR TITLE
Improved prompts that can also take into account conversations within the thread

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 // Slack bot that can talk to Open AI's GPT-3 by mentions to @openai using Open AI's Node.js library, TypeScript and React
-
 require("dotenv").config();
 const { App } = require("@slack/bolt");
 const { Configuration, OpenAIApi } = require("openai");
@@ -27,39 +26,50 @@ const app = new App({
 // See https://api.slack.com/tutorials/tracks/responding-to-app-mentions
 app.event("app_mention", async ({ event, say }) => {
   try {
+    // Retrieve all the messages in the thread where the event was triggered
+    const threadTs = event.thread_ts || event.ts;
+    const channel = event.channel;
+    const thread = await app.client.conversations
+      .replies({
+        token: process.env.SLACK_BOT_TOKEN,
+        channel: channel,
+        ts: threadTs,
+      })
+      .then((res) => res.messages);
+    // Convert to a string so that it is in the form user: message
+    const messages = thread.map((message) => {
+      return `${message.user}: ${message.text}`;
+    });
+
     // Creates a completion for the provided prompt and parameters
     // See https://beta.openai.com/docs/api-reference/completions/create?lang=node.js
+    const prompt = `
+      Act as an AI assistant. Consider the following conversation flow and answer the last question. The language in which you answer does not necessarily have to be English, identify the language used in the conversation and use it.
+
+      ${messages.join("\n")}
+      ${event.user}: ${event.text.replace(/<@.*>/, "")}
+      AI: 
+    `;
     const response = await openai.createCompletion({
-      model: "text-davinci-003", // https://beta.openai.com/docs/models/gpt-3
-      prompt: event.text, // String | Array of strings
-      // suffix: null, // String | null
-      max_tokens: 140, // Number, 1-4096 for text-davinci-003. Defaults to 16
-      temperature: 0.9, // Number, 0.0-1.0. Defaults to 1
-      // n: 1, // Number, 1-100. Defaults to 1
-      // stream: false, // Boolean. Defaults to false
-      // logprobs: null, // Number, 0-5. Defaults to null
-      // echo: false, // Boolean. Defaults to false
-      // stop: "\n", // String | Array of strings. Defaults to null
-      // presence_penalty: 0, // Number between -2.0 and 2.0. Defaults to 0
-      // frequency_penalty: 0, // Number between -2.0 and 2.0. Defaults to 0
-      // best_of: 1, // Number. Defaults to 1
-      // logit_bias: null, // Object. Defaults to null
-      // user: null, // String
+      model: process.env.OPENAI_MODEL, // https://beta.openai.com/docs/models/gpt-3
+      prompt: prompt, // String | Array of strings
+      max_tokens: 400, // Roughly 100 tokens ~= 75 words. 1-2048 for the latest models. 1-4096 for text-davinci-003. Defaults to 16
+      temperature: 0.9, // Higher values means the model will take more risks and be more creative, 0.0-1.0. Defaults to 1
+      // n: 1, // How many completions to generate for each prompt. 1-100. Defaults to 1. Set more than 1 if we enable user to retry
+      // stop: ["Human:", "AI:"], // String | Array of strings. Defaults to null
+      presence_penalty: 0.6, // Positive values enforce the model to talk about new topics.Between -2.0 and 2.0. Defaults to 0
+      // frequency_penalty: 0, // Negative values enforce the model to repeat the same line verbatim. Between -2.0 and 2.0. Defaults to 0
     });
 
     // Response to the message in the thread where the event was triggered with @${message.user} using openai's node.js library
     // See https://slack.dev/bolt-js/concepts#message-sending
-    console.log("event.text", event.text);
-    console.log("response.choices[0].text", response.choices[0].text);
-
     await say({
-      // text: `<@${event.user}>! ${response.choices[0].text}`,
-      text: `<@${event.user}>!`,
+      text: `<@${event.user}> ${response.data.choices[0].text}`,
       thread_ts: event.ts,
     });
   } catch (error) {
     await say({
-      text: `<@${event.user}> ${error.message}. ${error.response.statusText}.`,
+      text: `<@${event.user}> ${error.message}. ${error.response.statusText}.`, // @userName Request failed with status code 429. Too Many Requests.
       thread_ts: event.ts,
     });
   }


### PR DESCRIPTION
## Issue & Solution

To improve the chatbot capabilities of GPT-3, we implemented two strategies:

1. We instructed GPT-3 to read and respond to the entire thread of conversation in the Slack thread when mentioned with @openai.
2. We instructed GPT-3 to act as an AI assistant and refer to the conversation thread in order to provide a more relevant response to the final question.

By implementing these strategies, we are able to simulate a chatbot conversation with GPT-3 better.

## Reference

### OpenAI

- [Example for chat](https://beta.openai.com/examples/default-chat)

### Slack API

- [API: conversations.replies](https://api.slack.com/methods/conversations.replies)
- [API: conversations.history](https://api.slack.com/methods/conversations.history)

### JavaScript

- [Array.prototype.map()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map)