### PR TITLE
Implemented OAuth 2.0 without storing/fetching database

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,4 +1,3 @@
-// See https://medium.com/@sudarshanadayananda/how-to-live-reload-typescript-node-server-bc40171fdb7
 {
   "ignore": ["**/*.test.ts", "**/*.spec.ts", "node_modules"],
   "watch": ["src"],

--- a/src/lib/randomTextGenerator.ts
+++ b/src/lib/randomTextGenerator.ts
@@ -1,0 +1,15 @@
+// Create a variable length random string
+const unguessableRandomString = (outputLength: number) => {
+  const stringPool =
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+  // Array.from() creates an array from an iterable object
+  // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from
+  const randomString = Array.from(
+    { length: outputLength },
+    () => stringPool[Math.floor(Math.random() * stringPool.length)]
+  ).join("");
+  return randomString;
+};
+
+export default unguessableRandomString;

--- a/src/lib/slackAuth.ts
+++ b/src/lib/slackAuth.ts
@@ -1,34 +1,98 @@
-import routes from '../config/routes';
+import routes from "../config/routes";
+// import { Installation, InstallQuery } from "../types/slackTypes";
+import unguessableRandomString from "./randomTextGenerator";
 require("dotenv").config();
 const { App, LogLevel } = require("@slack/bolt");
+const { FileInstallationStore } = require('@slack/oauth');
 
-// Initialize Slack app with bot token and signing secret
+// Initialize Slack app with OAuth 2.0
 // See https://slack.dev/bolt-js/tutorial/getting-started#setting-up-your-project
+// And see https://slack.dev/bolt-js/concepts#authenticating-oauth
 const app = new App({
-  token: process.env.SLACK_BOT_TOKEN, // For both Socket Mode and HTTP
-  signingSecret: process.env.SLACK_SIGNING_SECRET, // For both Socket Mode and HTTP
-  // clientId: process.env.SLACK_CLIENT_ID, // For OAuth 2.0 only
-  // clientSecret: process.env.SLACK_CLIENT_SECRET, // For OAuth 2.0 only
-  // scopes: [
-  //   "app_mentions:read",
-  //   "channels:history",
-  //   "chat:write",
-  //   "groups:history",
-  //   "im:history",
-  //   "mpim:history",
-  // ], // For OAuth 2.0 only
-  // socketMode: true, // For Socket Mode only
-  // appToken: process.env.SLACK_APP_TOKEN, // For Socket Mode only
-  port: Number(process.env.PORT) || 3000, // For both HTTP and OAuth 2.0
+  signingSecret: process.env.SLACK_SIGNING_SECRET,
+  clientId: process.env.SLACK_CLIENT_ID,
+  clientSecret: process.env.SLACK_CLIENT_SECRET,
+  stateSecret: unguessableRandomString(32),
+  scopes: [
+    "app_mentions:read",
+    "channels:history",
+    "chat:write",
+    "groups:history",
+    "im:history",
+    "mpim:history",
+  ],
+  installationStore: new FileInstallationStore(),
+  // installationStore: {
+  //   // Bolt will pass your handler an installation object
+  //   storeInstallation: async (installation: Installation) => {
+  //     // handle storing org-wide app installation
+  //     if (
+  //       installation.isEnterpriseInstall &&
+  //       installation.enterprise !== undefined
+  //     ) {
+  //       return
+  //       // return await database.set(installation.enterprise.id, installation);
+  //     }
+
+  //     // single team app installation
+  //     if (installation.team !== undefined) {
+  //       return
+  //       // return await database.set(installation.team.id, installation);
+  //     }
+
+  //     // Else, throw an error
+  //     throw new Error("Failed saving installation data to installationStore");
+  //   },
+  //   // Bolt will pass your handler an installQuery object
+  //   fetchInstallation: async (installQuery: InstallQuery) => {
+  //     // handle org wide app installation lookup
+  //     if (
+  //       installQuery.isEnterpriseInstall &&
+  //       installQuery.enterpriseId !== undefined
+  //     ) {
+  //       return
+  //       // return await database.get(installQuery.enterpriseId);
+  //     }
+
+  //     // single team app installation lookup
+  //     if (installQuery.teamId !== undefined) {
+  //       return
+  //       // return await database.get(installQuery.teamId);
+  //     }
+
+  //     // Else, throw an error
+  //     throw new Error("Failed fetching installation");
+  //   },
+  //   // Bolt will pass your handler an installQuery object
+  //   deleteInstallation: async (installQuery: InstallQuery) => {
+  //     // org wide app installation deletion
+  //     if (
+  //       installQuery.isEnterpriseInstall &&
+  //       installQuery.enterpriseId !== undefined
+  //     ) {
+  //       return
+  //       // return await database.delete(installQuery.enterpriseId);
+  //     }
+
+  //     // single team app installation deletion
+  //     if (installQuery.teamId !== undefined) {
+  //       return
+  //       // return await database.delete(installQuery.teamId);
+  //     }
+
+  //     // Else, throw an error
+  //     throw new Error("Failed to delete installation");
+  //   },
+  // },
   logLevel: LogLevel.INFO, // Or LogLevel.DEBUG for debugging
-  customRoutes: routes
+  customRoutes: routes,
 });
 
 // Start bolt for JavaScript
 (async () => {
   // Start your app
   await app.start();
-  console.log('⚡️ Bolt app is running!');
+  console.log("⚡️ Bolt app is running!");
 })();
 
 export default app;

--- a/src/types/slackTypes.ts
+++ b/src/types/slackTypes.ts
@@ -29,4 +29,22 @@ interface Event {
   event_ts: string; // '1670833732.610129'
 }
 
-export type { Element, Block, Event };
+interface Installation {
+  isEnterpriseInstall: boolean;
+  enterprise?: {
+    id: string;
+    name: string;
+  };
+  team?: {
+    id: string;
+    name: string;
+  };
+}
+
+interface InstallQuery {
+  isEnterpriseInstall: boolean;
+  enterpriseId?: string;
+  teamId?: string;
+}
+
+export type { Element, Block, Event, Installation, InstallQuery };


### PR DESCRIPTION
## Issue & Solution

Originally, we were able to communicate with Slack through HTTP, but this was not compatible with OAuth2.0. In order to be able to use it across workspaces, it was necessary to do so.

## Reference

- [Authenticating with OAuth](https://slack.dev/bolt-js/concepts#authenticating-oauth)
- [OAuth フローの実装](https://slack.dev/bolt-js/ja-jp/concepts#authenticating-oauth)
- [Slack Bolt で簡単に複数ワークスペースにインストールできるアプリを開発しよう！（TypeScript, Lambda, Serverless Framework によるサンプルコード付き）](https://qiita.com/irongineer/items/9f0b997bbf62ae0d0e06)